### PR TITLE
merge setpath into makejar to fix building

### DIFF
--- a/makejar
+++ b/makejar
@@ -1,4 +1,6 @@
-. setpath
+#!/bin/bash
+
+export CLASSPATH=forms-1.1.0.jar:.
 
 javac AuthenticatorGUI.java
 

--- a/setpath
+++ b/setpath
@@ -1,1 +1,0 @@
-export CLASSPATH=forms-1.1.0.jar:.


### PR DESCRIPTION
Since the first line of "makejar" was buggy and I couldn't figure why you put the export in a separate file, I just merged it into the makejar script. Also added the usual line for a bash script to the head. After that it builded flawless for me.
