### PR TITLE
fixed installer links in readme.

### DIFF
--- a/README
+++ b/README
@@ -13,11 +13,11 @@ Explanatory bloggage at http://blog.jcuff.net/2011/09/beautiful-two-factor-deskt
 Installation using GUI Installer
 --------------------------------
 
-OS X       https://github.com/mclamp/JAuth/tree/master/Installers/JAuth_macos_1_0.dmg
-Windows    https://github.com/mclamp/JAuth/tree/master/Installers/JAuth_windows_1_0.dmg
-Linux      https://github.com/mclamp/JAuth/tree/master/Installers/JAuth_unix_1_0.dmg
+OS X       https://github.com/downloads/mclamp/JAuth/JAuth_macos_1_0.dmg
+Windows    https://github.com/downloads/mclamp/JAuth/JAuth_windows_1_0.exe
+Linux      https://github.com/downloads/mclamp/JAuth/JAuth_unix_1_0.sh
 
-All installers available from https://github.com/mclamp/JAuth/tree/master/Installers
+All installers available from https://github.com/mclamp/JAuth/downloads
 
 Installation
 ------------


### PR DESCRIPTION
fixed links to go to the actual downloadable exe installers instead of their location in the source tree.
