### PR TITLE
Set explicit path to setpath in makejar

### DIFF
--- a/makejar
+++ b/makejar
@@ -1,4 +1,4 @@
-. setpath
+. ./setpath
 
 javac JAuth/AuthenticatorGUI.java
 


### PR DESCRIPTION
Fixes an issue where makejar will fail if "." (the current directory) is not in the user's $PATH.

I didn't clutter up the actual commit message with this paragraph, but just FYI: the rationale behind changing this to an explicit path reference (of "./") is that having the current directory in $PATH is a security concern, albeit a rare one.  The idea is that if a malicious user can get an executable with a common name (for example, a shell script named "ls") into a common location (such as a user's home directory), then it's fairly likely that the target will eventually run that executable; removing "." from $PATH avoids this.
