### PR TITLE
Add ignore file to cover build output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/com/
+/JAuth.jar
+/META-INF/
+/manifest
+*.class


### PR DESCRIPTION
Create a basic .gitignore file to cover the output files created by the build process.

**Before you merge this pull request**
It's worth noting that while I'm a pretty advanced git user, I'm _not_ an expert Java programmer (although I did write a program to evaluate arbitrarily complex arithmetic expressions involving multi-sided die roll notation -- think tabletop RPGs -- which is pretty nerdy even for a Java programmer :P) so I would recommend that if you do plan to merge this pull request, take a close look at the directories/patterns listed and make sure it's not getting anything that's not "build output"; you're almost certainly more familiar with the specifics of the Java build process than I am, so you may spot something that shouldn't be in there.
